### PR TITLE
Update qhasharr.c

### DIFF
--- a/include/qlibc/containers/qhasharr.h
+++ b/include/qlibc/containers/qhasharr.h
@@ -93,7 +93,6 @@ struct qhasharr_data_s {
     int maxslots;       /*!< number of maximum slots */
     int usedslots;      /*!< number of used slots */
     int num;            /*!< number of stored keys */
-    qhasharr_slot_t *slots;  /*!< data area pointer */
 };
 
 /**


### PR DESCRIPTION
Fix the bug that use qhasharr in the share memory may collapse!

qhasharr is Static(array) hash-table, and we use it in share memory, then we have got a problems;
The problem is that if more than one process access the qhasharr, it may collapse;
Then we try to find out why it may happen, the reason is that:
The definition of qhasharr_data is :
    struct qhasharr_data_s {
        int maxslots;       /*!< number of maximum slots */
        int usedslots;      /*!< number of used slots */
        int num;            /*!< number of stored keys */
        qhasharr_slot_t *slots;  /*!< data area pointer */
    };
If one process starts, it call function *qhasharr(void *memory, size_t memsize) to initialize qhasharr_t, and it will execute the statement: data->slots = (qhasharr_slot_t *) (memory + sizeof(qhasharr_data_t));
The problem is that if parameter "memory" is the address of share memory (memory = shmat();)  and the address will be different in different processes of the same share memory, so that the address of slots will be changed by different processes, then different processes use data->slots[hash] will encounter problems;

So you may not store the address of slots, but use (qhasharr_slot_t *)((char*)(tbl->data) + sizeof(qhasharr_t)) to get the address of slots if you need to use the slots;
