### PR TITLE
Fix compile failure on debug build

### DIFF
--- a/src/containers/qhasharr.c
+++ b/src/containers/qhasharr.c
@@ -755,7 +755,9 @@ static bool debug(qhasharr_t *tbl, FILE *out) {
         return false;
     }
 
-    //qhasharr_data_t *data = tbl->data;
+#ifdef BUILD_DEBUG
+    qhasharr_data_t *data = tbl->data;
+#endif
     qhasharr_slot_t *tblslots = _get_slots(tbl);
 
     int idx = 0;


### PR DESCRIPTION
The following DEBUG code block will access qhasharr_data_t *data