### PR TITLE
Various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ INCLUDE_DIRECTORIES(${qlibc_SOURCE_DIR}/include/qlibc)
 INCLUDE_DIRECTORIES(${qlibc_SOURCE_DIR}/src/internal)
 
 SET(SRC_SUBPATHS
-		containers/*.c 
-		utilities/*.c 
-		ipc/*.c 
+		containers/*.c
+		utilities/*.c
+		ipc/*.c
 		internal/*.c)
 
 SET(SRC_SUBPATHS_EXT
@@ -28,19 +28,19 @@ FOREACH(TMP_path IN LISTS SRC_PATHS)
 		SET(TMP_search_path "${TMP_path}/${TMP_subpath}")
 		SET(SRC_SEARCH_PATHS ${SRC_SEARCH_PATHS} ${TMP_search_path})
 	ENDFOREACH(TMP_subpath)
-ENDFOREACH(TMP_elem)
+ENDFOREACH(TMP_path)
 
 FOREACH(TMP_path IN LISTS SRC_PATHS)
 	FOREACH(TMP_subpath IN LISTS SRC_SUBPATHS_EXT)
 		SET(TMP_search_path "${TMP_path}/${TMP_subpath}")
 		SET(SRC_SEARCH_PATHS_EXT ${SRC_SEARCH_PATHS_EXT} ${TMP_search_path})
 	ENDFOREACH(TMP_subpath)
-ENDFOREACH(TMP_elem)
+ENDFOREACH(TMP_path)
 
-FILE(GLOB_RECURSE SRC_LIB 
+FILE(GLOB_RECURSE SRC_LIB
 		${SRC_SEARCH_PATHS})
 
-FILE(GLOB_RECURSE SRC_LIB_EXT 
+FILE(GLOB_RECURSE SRC_LIB_EXT
 		${SRC_SEARCH_PATHS_EXT})
 
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${qlibc_SOURCE_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 What's qLibc?
 =============
 
-qLibc is currently one of the most functionally-complete public licensed C/C++ libraries. The goal of qLibc project is to provide a **simple and powerful general purpose C/C++ library**, which includes all kinds of containers and general library routines. It provides ready-made set of common container APIs with a consistent API look.
+qLibc is currently one of the most functionally-complete, publicly-licensed C/C++ libraries. The goal of the qLibc project is to provide a **simple and powerful general purpose C/C++ library** that includes all kinds of containers and general library routines. It provides a ready-made set of common container APIs with a consistent API look.
 
 ## qLibc Copyright
 
@@ -38,11 +38,11 @@ All of the deliverable code in qLibc has been dedicated to the public domain by 
 
 ## Consistent API Look
 
-All container APIs have a consistent look and feel. Basically, it provides a creator function which usually returns a pointer of a container structure. And **all functions related to the container can be accessed through function pointers inside of the container**.
+All container APIs have a consistent look and feel. It basically provides a creator function which usually returns a pointer to a container structure. Also, **all functions related to the container can be accessed through function pointers inside of the container**.
 
-So, regardless of which container you use, you can simply put elements into list like pContainer->put(pContainer, ...). It looks like C++ class but it's pure C implementation. Of course it works with both of your C and C++ code**.
+So, regardless of which container you use, you can simply put elements into a list with `pContainer->put(pContainer, ...)`. It looks like C++ classes, but it's a pure C implementation. Of course, it works with both C and C++ code**.
 
-We used this concept as much as possible because it is a simplified way of thinking and helps to improve readability. Consequently, it helps people to write bug-free code more easily.
+We use this concept as much as possible because it is a simplified way of thinking and helps to improve readability. Consequently, it helps people to write bug-free code more easily.
 
 The example below illustrates qlibc in action:
 
@@ -66,7 +66,7 @@ The example below illustrates qlibc in action:
 ```
 
 Here is an identical implementation with a Linked-List-Table container.
-You may notice that there isn't any code change at all, except for 1 line in the table creation.
+You may notice that there aren't any code changes at all, except for 1 line in the table creation.
 This is why qLibc encapsulates corresponding function pointers inside of the container object.
 
 ```C

--- a/include/qlibc/extensions/qaconf.h
+++ b/include/qlibc/extensions/qaconf.h
@@ -174,7 +174,7 @@ enum qaconf_otype {
 struct qaconf_s {
     /* capsulated member functions */
     int (*addoptions) (qaconf_t *qaconf, const qaconf_option_t *options);
-    void (*setdefhandler) (qaconf_t *qaconf, const qaconf_cb_t *callback);
+    void (*setdefhandler) (qaconf_t *qaconf, qaconf_cb_t *callback);
     void (*setuserdata) (qaconf_t *qaconf, const void *userdata);
     int (*parse) (qaconf_t *qaconf, const char *filepath, uint8_t flags);
     const char *(*errmsg) (qaconf_t *qaconf);

--- a/src/extensions/qaconf.c
+++ b/src/extensions/qaconf.c
@@ -210,7 +210,7 @@
 
 /* internal functions */
 static int addoptions(qaconf_t *qaconf, const qaconf_option_t *options);
-static void setdefhandler(qaconf_t *qaconf, const qaconf_cb_t *callback);
+static void setdefhandler(qaconf_t *qaconf, qaconf_cb_t *callback);
 static void setuserdata(qaconf_t *qaconf, const void *userdata);
 static int parse(qaconf_t *qaconf, const char *filepath, uint8_t flags);
 static const char *errmsg(qaconf_t *qaconf);
@@ -463,7 +463,7 @@ static int addoptions(qaconf_t *qaconf, const qaconf_option_t *options) {
  * @param qaconf qaconf_t object.
  * @param callback callback function pointer
  */
-static void setdefhandler(qaconf_t *qaconf, const qaconf_cb_t *callback) {
+static void setdefhandler(qaconf_t *qaconf, qaconf_cb_t *callback) {
     qaconf->defcb = callback;
 }
 

--- a/src/internal/qinternal.h
+++ b/src/internal/qinternal.h
@@ -130,7 +130,11 @@
 #define DEBUG(fmt, args...) fprintf(stderr, "[DEBUG] " fmt " (%s:%d)\n", \
                                     ##args, __FILE__, __LINE__);
 #else
-#define DEBUG(fms, args...)
+#ifdef __cplusplus
+#define DEBUG(fmt, args...) static_cast<void>(0)
+#else
+#define DEBUG(fmt, args...) (void)(0)
+#endif
 #endif  /* BUILD_DEBUG */
 
 // debug timer

--- a/src/utilities/qtime.c
+++ b/src/utilities/qtime.c
@@ -30,6 +30,9 @@
  * @file qtime.c Time handling APIs.
  */
 
+#define __USE_XOPEN
+#define _XOPEN_SOURCE
+#define _BSD_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>


### PR DESCRIPTION
1. Fix some grammar errors in README.md
2. Fix CMake warnings
3. Fix Clang warnings:
  1. A constant callback function is useless and undefined by the C standard
  2. In order to prevent an empty if statement warning, the debug macro is now set to be `(void)(0)`. Got it from `assert.h`.
  3. I had to define the given macros to build

Some notes:
- Why are there two licenses? The LICENSE file has a BSD license, but the README uses the public domain.
- Another warning appeared:

```
src/extensions/qhttpclient.c:792:33: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
            } else if (recvsize < 0) {
```

Wasn't sure how this should be fixed.

This project looks awesome! Just what I've been wanting!