### PR TITLE
fix error:undefined reference to `clock_gettime'

### DIFF
--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -45,7 +45,7 @@ TARGETS1	= \
 			test_qhasharr		\
 			test_qhasharr_darkdh \
 			test_qtreetbl		\
-			test_qstring
+			test_qstring		
 
 TARGETS2	= ${TARGETS1}
 TARGETS		= ${@EXAMPLES_TARGETS@}
@@ -60,19 +60,19 @@ test:	all
 	@./launcher.sh ${TARGETS}
 
 test_qtreetbl: test_qtreetbl.o
-	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qtreetbl.o ${LIBQLIBC} -lm
+	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qtreetbl.o ${LIBQLIBC} -lm -lrt
 
 test_qhashtbl: test_qhashtbl.o
-	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qhashtbl.o ${LIBQLIBC}
+	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qhashtbl.o ${LIBQLIBC} -lrt
 
 test_qhasharr: test_qhasharr.o
-	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qhasharr.o ${LIBQLIBC}
+	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qhasharr.o ${LIBQLIBC} -lrt
 
 test_qhasharr_darkdh: test_qhasharr_darkdh.o
-	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qhasharr_darkdh.o ${LIBQLIBC}
+	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qhasharr_darkdh.o ${LIBQLIBC} -lrt
 
 test_qstring: test_qstring.o
-	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qstring.o ${LIBQLIBC}
+	${CC} ${CFLAGS} ${CPPFLAGS} -o $@ test_qstring.o ${LIBQLIBC} -lrt
 
 ## Clear Module
 clean:


### PR DESCRIPTION
When I compiles the test source files, the following errors are thrown out:

```
qlibc/tests/test_qhashtbl.c:34: undefined reference to `clock_gettime'
qlibc/tests/test_qhashtbl.c:34: undefined reference to `clock_gettime'
qlibc/tests/test_qhashtbl.c:96: undefined reference to `clock_gettime'
qlibc/tests/test_qhashtbl.c:96: undefined reference to `clock_gettime'
qlibc/tests/test_qhashtbl.c:100: undefined reference to `clock_gettime'
test_qhashtbl.o:qlibc/tests/test_qhashtbl.c:100: more undefined references to `clock_gettime' follow

qlibc/tests/test_qhasharr.c:37: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr.c:37: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr.c:70: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr.c:70: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr.c:79: undefined reference to `clock_gettime'
test_qhasharr.o:qlibc/tests/test_qhasharr.c:79: more undefined references to `clock_gettime' follow

qlibc/tests/test_qhasharr_darkdh.c:38: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr_darkdh.c:38: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr_darkdh.c:67: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr_darkdh.c:67: undefined reference to `clock_gettime'
qlibc/tests/test_qhasharr_darkdh.c:83: undefined reference to `clock_gettime'
test_qhasharr_darkdh.o:qlibc/tests/test_qhasharr_darkdh.c:83: more undefined references to `clock_gettime' follow

qlibc/tests/test_qtreetbl.c:60: undefined reference to `clock_gettime'
qlibc/tests/test_qtreetbl.c:60: undefined reference to `clock_gettime'
qlibc/tests/test_qtreetbl.c:100: undefined reference to `clock_gettime'
qlibc/tests/test_qtreetbl.c:100: undefined reference to `clock_gettime'
qlibc/tests/test_qtreetbl.c:131: undefined reference to `clock_gettime'
test_qtreetbl.o:qlibc/tests/test_qtreetbl.c:131: more undefined references to `clock_gettime' follow

qlibc/tests/test_qstring.c:34: undefined reference to `clock_gettime'
qlibc/tests/test_qstring.c:34: undefined reference to `clock_gettime'
qlibc/tests/test_qstring.c:52: undefined reference to `clock_gettime'
qlibc/tests/test_qstring.c:52: undefined reference to `clock_gettime'
qlibc/tests/test_qstring.c:62: undefined reference to `clock_gettime'
test_qstring.o:qlibc/tests/test_qstring.c:62: more undefined references to `clock_gettime' follow

```

The configuration of my environment is:

```
# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 6.2 (Santiago)
 gcc --version
gcc (GCC) 4.8.2 20140120 (Red Hat 4.8.2-15)
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```