### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 PROJECT(qlibc C)
 
 INCLUDE_DIRECTORIES(${qlibc_SOURCE_DIR}/include/qlibc)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,9 +37,9 @@ To see detailed configure options, use `--help` option:
 $ ./configure --help
 ```
 
-### MacOS X and Windows systems
+### All systems
 
-Run "cmake" command.
+Run the "cmake" command.
 
 ```
 $ cmake .


### PR DESCRIPTION
This:

- Fixes the minimum required CMake version
- Is explicit about the fact that CMake works on all platforms. I use it for building qlibc under Linux because of its Ninja generator (which is *much* faster than make).
