### PR TITLE
fix CFLAGS env not working

### DIFF
--- a/configure
+++ b/configure
@@ -3129,7 +3129,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 if test $ac_compiler_gnu = yes; then
-	CFLAGS="-Wall -Wstrict-prototypes -fPIC"
+	CFLAGS="$CFLAGS -Wall -Wstrict-prototypes -fPIC"
 #else
 #	AC_MSG_FAILURE([GCC is required.])
 fi


### PR DESCRIPTION
Export CFLAGS is not working because CFLAGS will be overwritten if not including original CFLAGS 