### PR TITLE
Add timestamp for hasharr

### DIFF
--- a/configure
+++ b/configure
@@ -722,6 +722,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_debug
+enable_qhasharr_ts
 enable_ipc
 enable_ext
 enable_ext_qconfig
@@ -1352,6 +1353,7 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-debug          Enable debugging output. This will print out
                           internal debugging messages to stdout.
+  --enable-qhasharr-ts    Enable qhash array timestamp function.
   --disable-ipc           Disable IPC APIs(src/ipc/) in qlibc library.
   --disable-ext           Disable building qlibext extension library.
   --disable-ext-qconfig   Disable qconfig extension in qlibext library.
@@ -4630,6 +4632,20 @@ fi
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: 'debug' feature is enabled" >&5
 $as_echo "$as_me: 'debug' feature is enabled" >&6;}
 		CPPFLAGS="$CPPFLAGS -DBUILD_DEBUG"
+	fi
+
+
+	# Check whether --enable-qhasharr-ts was given.
+if test "${enable_qhasharr_ts+set}" = set; then :
+  enableval=$enable_qhasharr_ts;
+else
+  enableval=no
+fi
+
+	if test "$enableval" = yes; then
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: 'qhasharr-ts' feature is enabled" >&5
+$as_echo "$as_me: 'qhasharr-ts' feature is enabled" >&6;}
+		CPPFLAGS="$CPPFLAGS -DQHASHARR_TIMESTAMP"
 	fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -148,6 +148,7 @@ AC_SUBST(DEPLIBS, ["-lpthread"])
 ##
 
 Q_ARG_ENABLE([debug], [Enable debugging output. This will print out internal debugging messages to stdout.], [-DBUILD_DEBUG])
+Q_ARG_ENABLE([qhasharr-ts], [Enable qhash array timestamp function.], [-DQHASHARR_TIMESTAMP])
 
 Q_ARG_DISABLE([ipc], [Disable IPC APIs(src/ipc/) in qlibc library.], [-DDISABLE_IPC])
 Q_ARG_DISABLE([ext], [Disable building qlibext extension library.], [])

--- a/examples/hasharr.c
+++ b/examples/hasharr.c
@@ -30,6 +30,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
+#ifdef QHASHARR_TIMESTAMP
+#include <unistd.h>
+#endif
 #include "qlibc.h"
 
 int main(void) {
@@ -40,13 +43,20 @@ int main(void) {
     if (tbl == NULL) {
         return -1;
     }
-
+#ifdef QHASHARR_TIMESTAMP
+    time_t t;
+    struct tm *tm_p;
+    char buf[128];
+#endif
     //
     // TEST 1 : adding elements.
     //
 
     // insert elements (key duplication is not allowed)
     tbl->putstr(tbl, "e1", "a");
+#ifdef QHASHARR_TIMESTAMP
+        sleep(2);
+#endif
     tbl->putstr(tbl, "e2", "b");
     tbl->putstr(tbl, "e2", "c");
     tbl->putstr(tbl, "e3", "d");
@@ -54,6 +64,20 @@ int main(void) {
     tbl->putstr(tbl, "e5", "f");
     tbl->putstr(tbl, "12345678901234567890",
                 "1234567890123456789012345678901234567890");
+
+#ifdef QHASHARR_TIMESTAMP
+    tbl->getts(tbl, "e1", &t);
+    tm_p = localtime(&t);
+    memset(buf, 0, sizeof(buf));
+    strftime(buf, sizeof(buf), "%x - %I:%M:%S%p", tm_p);
+    printf("time %s\n", buf);
+
+    tbl->getts(tbl, "e5", &t);
+    tm_p = localtime(&t);
+    memset(buf, 0, sizeof(buf));
+    strftime(buf, sizeof(buf), "%x - %I:%M:%S%p", tm_p);
+    printf("time %s\n", buf);
+#endif
 
     // print out
     printf("--[Test 1 : adding elements]--\n");
@@ -63,12 +87,23 @@ int main(void) {
     // TEST 2 : many ways to find key.
     //
 
+#ifdef QHASHARR_TIMESTAMP
+    sleep(2);
+#endif
     printf("\n--[Test 2 : many ways to find key]--\n");
     char *e2 = tbl->getstr(tbl, "e2");
     if (e2 != NULL) {
         printf("getstr('e2') : %s\n", e2);
         free(e2);
     }
+
+#ifdef QHASHARR_TIMESTAMP
+    tbl->getts(tbl, "e2", &t);
+    tm_p = localtime(&t);
+    memset(buf, 0, sizeof(buf));
+    strftime(buf, sizeof(buf), "%x - %I:%M:%S%p", tm_p);
+    printf("time %s\n", buf);
+#endif
 
     //
     // TEST 3 : travesal table.

--- a/include/qlibc/containers/qhasharr.h
+++ b/include/qlibc/containers/qhasharr.h
@@ -38,6 +38,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
+#ifdef QHASHARR_TIMESTAMP
+#include <time.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,23 +65,29 @@ typedef struct qhasharr_obj_s qhasharr_obj_t;
 extern qhasharr_t *qhasharr(void *memory, size_t memsize);
 extern size_t qhasharr_calculate_memsize(int max);
 
-extern bool qhasharr_put(qhasharr_t *tbl, const char *key, const void *value,
+extern bool qhasharr_put(qhasharr_t *tbl, const char *name, const void *value,
                 size_t size);
-extern bool qhasharr_putstr(qhasharr_t *tbl, const char *key, const char *str);
-extern bool qhasharr_putstrf(qhasharr_t *tbl, const char *key, const char *format, ...);
+extern bool qhasharr_putstr(qhasharr_t *tbl, const char *name, const char *str);
+extern bool qhasharr_putstrf(qhasharr_t *tbl, const char *name, const char *format, ...);
 extern bool qhasharr_put_by_obj(qhasharr_t *tbl, const void *name, size_t namesize,
                                 const void *data, size_t datasize);
 
-extern void *qhasharr_get(qhasharr_t *tbl, const char *key, size_t *size);
-extern char *qhasharr_getstr(qhasharr_t *tbl, const char *key);
+extern void *qhasharr_get(qhasharr_t *tbl, const char *name, size_t *size);
+extern char *qhasharr_getstr(qhasharr_t *tbl, const char *name);
 extern void *qhasharr_get_by_obj(qhasharr_t *tbl, const void *name, size_t namesize,
                                  size_t *datasize);
 
-extern bool qhasharr_remove(qhasharr_t *tbl, const char *key);
-extern bool qhasharr_remove_by_obj(qhasharr_t *tbl, const char *name, size_t namesize);
+extern bool qhasharr_remove(qhasharr_t *tbl, const char *name);
+extern bool qhasharr_remove_by_obj(qhasharr_t *tbl, const void *name, size_t namesize);
 extern bool qhasharr_remove_by_idx(qhasharr_t *tbl, int idx);
 
 extern bool qhasharr_getnext(qhasharr_t *tbl, qhasharr_obj_t *obj, int *idx);
+
+#ifdef QHASHARR_TIMESTAMP
+extern bool qhasharr_getts(qhasharr_t *tbl, const char *name, time_t *ts);
+extern bool qhasharr_getts_by_obj(qhasharr_t *tbl, const void *name,
+        size_t namesize, time_t *ts);
+#endif
 
 extern int qhasharr_size(qhasharr_t *tbl, int *maxslots, int *usedslots);
 extern void qhasharr_clear(qhasharr_t *tbl);
@@ -92,23 +101,29 @@ extern void qhasharr_free(qhasharr_t *tbl);
  */
 struct qhasharr_s {
     /* encapsulated member functions */
-    bool (*put) (qhasharr_t *tbl, const char *key, const void *value,
+    bool (*put) (qhasharr_t *tbl, const char *name, const void *value,
                  size_t size);
-    bool (*putstr) (qhasharr_t *tbl, const char *key, const char *str);
-    bool (*putstrf) (qhasharr_t *tbl, const char *key, const char *format, ...);
+    bool (*putstr) (qhasharr_t *tbl, const char *name, const char *str);
+    bool (*putstrf) (qhasharr_t *tbl, const char *name, const char *format, ...);
     bool (*put_by_obj) (qhasharr_t *tbl, const void *name, size_t namesize,
                         const void *data, size_t datasize);
 
-    void *(*get) (qhasharr_t *tbl, const char *key, size_t *size);
-    char *(*getstr) (qhasharr_t *tbl, const char *key);
+    void *(*get) (qhasharr_t *tbl, const char *name, size_t *size);
+    char *(*getstr) (qhasharr_t *tbl, const char *name);
     void *(*get_by_obj) (qhasharr_t *tbl, const void *name, size_t namesize,
                          size_t *datasize);
 
-    bool (*remove) (qhasharr_t *tbl, const char *key);
-    bool (*remove_by_obj) (qhasharr_t *tbl, const char *name, size_t namesize);
+    bool (*remove) (qhasharr_t *tbl, const char *name);
+    bool (*remove_by_obj) (qhasharr_t *tbl, const void *name, size_t namesize);
     bool (*remove_by_idx) (qhasharr_t *tbl, int idx);
 
     bool (*getnext) (qhasharr_t *tbl, qhasharr_obj_t *obj, int *idx);
+
+#ifdef QHASHARR_TIMESTAMP
+    bool (*getts) (qhasharr_t *tbl, const char *key, time_t *ts);
+    bool (*getts_by_obj) (qhasharr_t *tbl, const void *name, size_t namesize,
+            time_t *ts);
+#endif
 
     int  (*size) (qhasharr_t *tbl, int *maxslots, int *usedslots);
     void (*clear) (qhasharr_t *tbl);
@@ -130,6 +145,9 @@ struct qhasharr_slot_s {
     uint32_t  hash;    /*!< key hash */
     uint8_t datasize;  /*!< value size in this slot*/
     int link;          /*!< next link */
+#ifdef QHASHARR_TIMESTAMP
+    time_t timestamp;   /*!< timestamp of data */
+#endif
 
     union {
         /*!< key/value data */

--- a/tests/test_qhasharr_darkdh.c
+++ b/tests/test_qhasharr_darkdh.c
@@ -33,6 +33,9 @@
 #include "qunit.h"
 #include "qlibc.h"
 #include <errno.h>
+#ifdef QHASHARR_TIMESTAMP
+#include <unistd.h>
+#endif
 
 QUNIT_START("Test qhasharr.c by darkdh");
 
@@ -143,6 +146,32 @@ TEST("getnext()")
     }
     ASSERT_EQUAL_INT(tbl->size(tbl, NULL, NULL), TARGET_NUM);
 }
+#ifdef QHASHARR_TIMESTAMP
+TEST ("getts()") {
+    tbl->clear(tbl);
+    for(i = 0;i < TARGET_NUM; i++) {
+        ASSERT_TRUE(tbl->put(tbl, key[i], value[i],
+                    valuesize[i]));
+        sleep(1);
+    }
+    for(i = 1;i < TARGET_NUM; i++) {
+        time_t t1, t2;
+        ASSERT_TRUE(tbl->getts(tbl, key[i], &t2));
+        ASSERT_TRUE(tbl->getts(tbl, key[i - 1], &t1));
+        double timeinterval = difftime(t2, t1);
+        ASSERT_EQUAL_INT(timeinterval, 1);
+    }
+    for(i = 0;i < TARGET_NUM; i++) {
+        time_t t1, t2;
+        time(&t1);
+        ASSERT_NOT_NULL(tbl->getstr(tbl, key[i]));
+        ASSERT_TRUE(tbl->getts(tbl, key[i], &t2));
+        double timeinterval = difftime(t2, t1);
+        ASSERT_EQUAL_INT(timeinterval, 0);
+    }
+
+}
+#endif
 
 // free table reference object.
 tbl->free(tbl);


### PR DESCRIPTION
1. Add hasharr timestamp
2. Change argument naming
3. Fix qhasharr_remove_by_obj's name argument type

Sometimes we need a timeout mechanism to cleanup the static allocated hash table. Store time stamp in each slot entry and updated the time when get/set data. If we put time stamp in data, that will need extra memory copy (update time stamp and put data in) even if we just get data from table. However, each slot will cost extra space for time_t even if it is extended slot so we default disable this feature unless user configure to enable.