### PR TITLE
Fix #46 (and some other stuff)

### DIFF
--- a/include/qlibc/containers/qhashtbl.h
+++ b/include/qlibc/containers/qhashtbl.h
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/containers/qhashtbl.c
+++ b/src/containers/qhashtbl.c
@@ -176,7 +176,6 @@ qhashtbl_t *qhashtbl(size_t range, int options) {
     malloc_failure:
     errno = ENOMEM;
     if (tbl) {
-        free(tbl->slots);
         assert(tbl->qmutex == NULL);
         qhashtbl_free(tbl);
     }

--- a/src/internal/qinternal.h
+++ b/src/internal/qinternal.h
@@ -73,7 +73,6 @@ struct qmutex_s {
 };
 
 #define Q_MUTEX_NEW(m,r) do {                                           \
-        if(m == NULL) break;                                            \
         qmutex_t *x = (qmutex_t *)calloc(1, sizeof(qmutex_t));          \
         pthread_mutexattr_t _mutexattr;                                 \
         pthread_mutexattr_init(&_mutexattr);                            \

--- a/src/utilities/qtime.c
+++ b/src/utilities/qtime.c
@@ -30,9 +30,9 @@
  * @file qtime.c Time handling APIs.
  */
 
-//#define __USE_XOPEN
-//#define _XOPEN_SOURCE
-//#define _BSD_SOURCE
+#define __USE_XOPEN
+#define _XOPEN_SOURCE
+#define _BSD_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>


### PR DESCRIPTION
1. `stdio.h` needs to be included to use `FILE*`.
2. `Q_MUTEX_NEW` was incorrectly returning, which caused a jump to `malloc_failure`, which freed `tbl->slots` twice.
3. Those macros need to be defined for `strptime` to be available. Blame `glibc` configuration weirdness. :O
