### PR TITLE
md5: fix musl build by removing usage of internal glibc header sys/cd…

### DIFF
--- a/src/internal/md5/md5.h
+++ b/src/internal/md5/md5.h
@@ -35,9 +35,9 @@ typedef struct MD5Context {
     unsigned char buffer[64]; /* input buffer */
 } MD5_CTX;
 
-#include <sys/cdefs.h>
-
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 void MD5Init(MD5_CTX *);
 void MD5Update(MD5_CTX *, const unsigned char *, unsigned int);
 void MD5Final(unsigned char[16], MD5_CTX *);
@@ -45,6 +45,8 @@ char * MD5End(MD5_CTX *, char *);
 char * MD5File(const char *, char *);
 char * MD5FileChunk(const char *, char *, off_t, off_t);
 char * MD5Data(const unsigned char *, unsigned int, char *);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* Q_MD5_H */

--- a/src/internal/md5/md5c.c
+++ b/src/internal/md5/md5c.c
@@ -26,7 +26,6 @@
  * edited for clarity and style only.
  */
 
-#include <sys/cdefs.h>
 #include <sys/types.h>
 #include <string.h>
 #include "md5.h"


### PR DESCRIPTION
…efs.h

As suggested in musl FAQ:
http://wiki.musl-libc.org/wiki/FAQ#Q:_I.27m_trying_to_compile_something_against_musl_and_I_get_error_messages_about_sys.2Fcdefs.h