### PR TITLE
qvector: adjust num after resize.

### DIFF
--- a/src/containers/qvector.c
+++ b/src/containers/qvector.c
@@ -766,6 +766,9 @@ bool qvector_resize(qvector_t *vector, size_t newmax) {
 
     vector->data = newdata;
     vector->max = newmax;
+    if (vector->num > newmax) {
+        vector->num = newmax;
+    }
     
     vector->unlock(vector);
     return true;


### PR DESCRIPTION
Resize of num is required in case old num is bigger than newmax.