### PR TITLE
Allow to explicitly disable openssl and mysql

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ fi
 ## --with section
 ##
 
-AC_ARG_WITH([openssl],[AS_HELP_STRING([--with-openssl], [This will enable HTTPS support in qhttpclient extension API. When it's enabled, user applications will need to link openssl library with -lssl option.])],[withval=yes],[withval=no])
+AC_ARG_WITH([openssl],[AS_HELP_STRING([--with-openssl], [This will enable HTTPS support in qhttpclient extension API. When it's enabled, user applications will need to link openssl library with -lssl option.])],[],[withval=no])
 if test "$withval" = yes; then
 	if test "$with_openssl" = yes; then
 		with_openssl="/usr/include"
@@ -187,7 +187,7 @@ if test "$withval" = yes; then
 	fi
 fi
 
-AC_ARG_WITH([mysql],[AS_HELP_STRING([--with-mysql], [This will enable MySQL database support in qdatabase extension API. When it's enabled, user applications need to link mysql client library. (ex: -lmysqlclient)])],[withval=yes],[withval=no])
+AC_ARG_WITH([mysql],[AS_HELP_STRING([--with-mysql], [This will enable MySQL database support in qdatabase extension API. When it's enabled, user applications need to link mysql client library. (ex: -lmysqlclient)])],[],[withval=no])
 if test "$withval" = yes; then
 	if test "$with_mysql" = yes; then
 		with_mysql="/usr/include/mysql"


### PR DESCRIPTION
AC_ARG_WITH() is being incorrectly used: the third argument indicates
the action that needs to be taken when a value was passed, when not
the option is enabled. Therefore, the result of the existing code was
that when you passed --without-mysql or --without-openssl, the
$withval variable would get the value 'yes', which is obviously wrong.

Instead, we simply empty this third argument, because $withval is
already properly filled with 'yes' or 'no' by the AC_ARG_WITH()
function.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/qlibc/0003-fix-openssl-mysql-checks.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>