### PR TITLE
Add continuous integration to automatically run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Install dev packages
+        run: sudo apt-get install -y build-essential
+
+      # Runs a set of commands using the runners shell
+      - name: Compile the code
+        run: |
+          ./configure
+          make
+          make test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-What's qLibc?
+What's qLibc?  [![Actions Status](https://github.com/wolkykim/qlibc/workflows/CI/badge.svg)](https://github.com/wolkykim/qlibc/actions)
 =============
 
 qLibc is currently one of the most functionally-complete, publicly-licensed


### PR DESCRIPTION
Add .github/workflows/ci.yml and update README.md with a badge showing current build status.
Whenever there is a push to master, github will pull the latest code into a VM and run ./configure && make && make test
Feedback is displayed within 30s or so, and the badge will display the status of the last auto-build.