### PR TITLE
Check return value of sscanf()

### DIFF
--- a/src/extensions/qhttpclient.c
+++ b/src/extensions/qhttpclient.c
@@ -785,7 +785,10 @@ static bool get(qhttpclient_t *client, const char *uri, int fd, off_t *savesize,
 
             // parse chunk size
             unsigned int recvsize;  // this time chunk size
-            sscanf(buf, "%x", &recvsize);
+            if (sscanf(buf, "%x", &recvsize) != 1) {
+                break;
+            }
+
             if (recvsize == 0) {
                 // end of transfer
                 completed = true;


### PR DESCRIPTION
The variable recvsize is read, but may not have been written. It should be guarded by a check that the call to sscanf returns at least 1.