### PR TITLE
Alloc fail & fix compile warning

### DIFF
--- a/src/utilities/qio.c
+++ b/src/utilities/qio.c
@@ -303,7 +303,7 @@ ssize_t qio_puts(int fd, const char *str, int timeoutms) {
     char *newstr = (char *) malloc(strsize + 1 + 1);
     if (newstr == NULL)
         return -1;
-    memcpy(newstr, str, strsize);
+    strncpy(newstr, str, strsize);
     newstr[strsize] = '\n';
     newstr[strsize + 1] = '\0';
     ssize_t ret = qio_write(fd, newstr, strsize + 1, timeoutms);

--- a/src/utilities/qio.c
+++ b/src/utilities/qio.c
@@ -303,7 +303,7 @@ ssize_t qio_puts(int fd, const char *str, int timeoutms) {
     char *newstr = (char *) malloc(strsize + 1 + 1);
     if (newstr == NULL)
         return -1;
-    strncpy(newstr, str, strsize);
+    memcpy(newstr, str, strsize);
     newstr[strsize] = '\n';
     newstr[strsize + 1] = '\0';
     ssize_t ret = qio_write(fd, newstr, strsize + 1, timeoutms);

--- a/src/utilities/qsocket.c
+++ b/src/utilities/qsocket.c
@@ -112,8 +112,9 @@ bool qsocket_close(int sockfd, int timeoutms) {
         char buf[1024];
         while (true) {
             ssize_t read = qio_read(sockfd, buf, sizeof(buf), timeoutms);
+			DEBUG("Throw %zu bytes from dummy input stream.", read);
             if (read <= 0)
-                break;DEBUG("Throw %zu bytes from dummy input stream.", read);
+                break;
         }
     }
 

--- a/src/utilities/qsocket.c
+++ b/src/utilities/qsocket.c
@@ -112,7 +112,7 @@ bool qsocket_close(int sockfd, int timeoutms) {
         char buf[1024];
         while (true) {
             ssize_t read = qio_read(sockfd, buf, sizeof(buf), timeoutms);
-			DEBUG("Throw %zu bytes from dummy input stream.", read);
+            DEBUG("Throw %zu bytes from dummy input stream.", read);
             if (read <= 0)
                 break;
         }

--- a/src/utilities/qstring.c
+++ b/src/utilities/qstring.c
@@ -251,6 +251,9 @@ char *qstrreplace(const char *mode, char *srcstr, const char *tokstr,
     if (method == 't') { /* Token replace */
         maxstrlen = strlen(srcstr) * ((strlen(word) > 0) ? strlen(word) : 1);
         newstr = (char *) malloc(maxstrlen + 1);
+		if (newstr == NULL)
+			return NULL;
+			
 
         for (srcp = (char *) srcstr, newp = newstr; *srcp; srcp++) {
             for (tokenp = (char *) tokstr; *tokenp; tokenp++) {
@@ -274,6 +277,9 @@ char *qstrreplace(const char *mode, char *srcstr, const char *tokstr,
             maxstrlen = strlen(srcstr);
         }
         newstr = (char *) malloc(maxstrlen + 1);
+		if (newstr == NULL)
+			return NULL;
+
         tokstrlen = strlen(tokstr);
 
         for (srcp = srcstr, newp = newstr; *srcp; srcp++) {
@@ -389,6 +395,9 @@ char *qstrdup_between(const char *str, const char *start, const char *end) {
     int len = e - s;
 
     char *buf = (char *) malloc(sizeof(char) * (len + 1));
+	if (buf == NULL)
+		return NULL;
+
     strncpy(buf, s, len);
     buf[len] = '\0';
 
@@ -869,6 +878,7 @@ char *qstr_conv_encoding(const char *str, const char *fromcode,
     char *tostr = (char *) malloc(tosize);
     if (tostr == NULL)
         return NULL;
+
     char *tostr1 = tostr;
 
     iconv_t it = iconv_open(tocode, fromcode);

--- a/src/utilities/qstring.c
+++ b/src/utilities/qstring.c
@@ -397,7 +397,7 @@ char *qstrdup_between(const char *str, const char *start, const char *end) {
     if (buf == NULL)
         return NULL;
 
-    memcpy(buf, s, len);
+    strncpy(buf, s, len);
     buf[len] = '\0';
     return buf;
 }

--- a/src/utilities/qstring.c
+++ b/src/utilities/qstring.c
@@ -393,7 +393,11 @@ char *qstrdup_between(const char *str, const char *start, const char *end) {
 
     int len = e - s;
 
-    char *buf = qmemdup(s, len);
+    char *buf = (char *) malloc(sizeof(char) * (len + 1));
+    if (buf == NULL)
+        return NULL;
+
+    memcpy(buf, s, len);
     buf[len] = '\0';
     return buf;
 }

--- a/src/utilities/qstring.c
+++ b/src/utilities/qstring.c
@@ -251,9 +251,8 @@ char *qstrreplace(const char *mode, char *srcstr, const char *tokstr,
     if (method == 't') { /* Token replace */
         maxstrlen = strlen(srcstr) * ((strlen(word) > 0) ? strlen(word) : 1);
         newstr = (char *) malloc(maxstrlen + 1);
-		if (newstr == NULL)
-			return NULL;
-			
+        if (newstr == NULL)
+            return NULL;
 
         for (srcp = (char *) srcstr, newp = newstr; *srcp; srcp++) {
             for (tokenp = (char *) tokstr; *tokenp; tokenp++) {
@@ -277,8 +276,8 @@ char *qstrreplace(const char *mode, char *srcstr, const char *tokstr,
             maxstrlen = strlen(srcstr);
         }
         newstr = (char *) malloc(maxstrlen + 1);
-		if (newstr == NULL)
-			return NULL;
+        if (newstr == NULL)
+            return NULL;
 
         tokstrlen = strlen(tokstr);
 
@@ -394,13 +393,8 @@ char *qstrdup_between(const char *str, const char *start, const char *end) {
 
     int len = e - s;
 
-    char *buf = (char *) malloc(sizeof(char) * (len + 1));
-	if (buf == NULL)
-		return NULL;
-
-    strncpy(buf, s, len);
+    char *buf = qmemdup(s, len);
     buf[len] = '\0';
-
     return buf;
 }
 

--- a/src/utilities/qtime.c
+++ b/src/utilities/qtime.c
@@ -103,6 +103,9 @@ char *qtime_localtime_strf(char *buf, int size, time_t utctime,
 char *qtime_localtime_str(time_t utctime) {
     int size = sizeof(char) * (CONST_STRLEN("00-Jan-0000 00:00:00 +0000") + 1);
     char *timestr = (char *) malloc(size);
+	if (timestr == NULL)
+		return NULL;
+
     qtime_localtime_strf(timestr, size, utctime, "%d-%b-%Y %H:%M:%S %z");
     return timestr;
 }
@@ -172,6 +175,9 @@ char *qtime_gmt_str(time_t utctime) {
     int size = sizeof(char)
             * (CONST_STRLEN("Mon, 00 Jan 0000 00:00:00 GMT") + 1);
     char *timestr = (char *) malloc(size);
+	if (timestr == NULL)
+		return NULL;
+
     qtime_gmt_strf(timestr, size, utctime, "%a, %d %b %Y %H:%M:%S GMT");
     return timestr;
 }

--- a/src/utilities/qtime.c
+++ b/src/utilities/qtime.c
@@ -103,8 +103,8 @@ char *qtime_localtime_strf(char *buf, int size, time_t utctime,
 char *qtime_localtime_str(time_t utctime) {
     int size = sizeof(char) * (CONST_STRLEN("00-Jan-0000 00:00:00 +0000") + 1);
     char *timestr = (char *) malloc(size);
-	if (timestr == NULL)
-		return NULL;
+    if (timestr == NULL)
+        return NULL;
 
     qtime_localtime_strf(timestr, size, utctime, "%d-%b-%Y %H:%M:%S %z");
     return timestr;
@@ -175,8 +175,8 @@ char *qtime_gmt_str(time_t utctime) {
     int size = sizeof(char)
             * (CONST_STRLEN("Mon, 00 Jan 0000 00:00:00 GMT") + 1);
     char *timestr = (char *) malloc(size);
-	if (timestr == NULL)
-		return NULL;
+    if (timestr == NULL)
+        return NULL;
 
     qtime_gmt_strf(timestr, size, utctime, "%a, %d %b %Y %H:%M:%S GMT");
     return timestr;


### PR DESCRIPTION
I fix some compile warning and alloc fail(#104 ). 
But still occur two compile warning. Do you want to fix this complie warning? 

Here's my environment
* GCC : 13.1.1
* Arch: Linux arch 6.3.8-arch1-1 x86_64


```sh
extensions/qconfig.c: In function ‘qconfig_parse_file’:
extensions/qconfig.c:165:48: warning: ‘%s’ directive output may be truncated writing up to 4094 bytes into a region of size between 1 and 4095 [-Wformat-truncation=]
  165 |                 snprintf(tmp, sizeof(tmp), "%s/%s", dir, buf);
      |                                                ^~        ~~~
extensions/qconfig.c:165:17: note: ‘snprintf’ output between 2 and 8190 bytes into a destination of size 4096
  165 |                 snprintf(tmp, sizeof(tmp), "%s/%s", dir, buf);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```sh
gcc -g -O2 -Wall -Wstrict-prototypes -fPIC -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/include -I/usr/local/include -I../include/qlibc -I./internal -c -o utilities/qtime.o
 utilities/qtime.c                                                                                                                                                                             
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:27,
                 from utilities/qtime.c:36:
/usr/include/features.h:195:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]  
  195 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"                                         

```
