### PR TITLE
Fixed memory leak when assessing file permissions in qhash.c

### DIFF
--- a/src/utilities/qhash.c
+++ b/src/utilities/qhash.c
@@ -106,8 +106,10 @@ bool qhashmd5_file(const char *filepath, off_t offset, ssize_t nbytes,
         return false;
 
     struct stat st;
-    if (fstat(fd, &st) < 0)
+    if (fstat(fd, &st) < 0) {
+        close(fd);
         return false;
+    }
     size_t size = st.st_size;
 
     // check filesize


### PR DESCRIPTION
The current implementation of qhashmd5_file(...) fails to close an open file descriptor upon a failed call to fstat(...). While it's unlikely to occur as the file has just been opened, it's still good practice to clean up all allocated resources in the event of a failure.

This is my first commit to this repository. I do not see a commit style guide or commit guidelines. If I missed these guides, please let me know!