### PR TITLE
Added Installation section which includes basic instructions on how t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,8 @@ make
 sudo make install
 ```
 
-Alternatively, you can use Cmake. qLibc requires at least GNU99 and confirmed to be compiling in GNU23
+qLibc requires at least GNU99 and confirmed to be compiling in GNU23.
 
-```bash
-mkdir build
-cd build
-cmake ..
-sudo make install
-```
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ APIs with a consistent API look.
 qLibc is published under 2-clause BSD license known as Simplified BSD License.
 Please refer the LICENSE document included in the package for more details.
 
+## Installation
+
+qlibc uses GNU AutoTools as the primary tool for compilation. Simply execute the following commands while in the main directory of the project.
+
+```bash
+./configure
+make
+sudo make install
+```
+
+Alternatively, you can use Cmake. qLibc requires at least GNU99 and confirmed to be compiling in GNU23
+
+```bash
+mkdir build
+cd build
+cmake ..
+sudo make install
+```
+
 ## API Reference
 
 * [qlibc Core API Reference](https://wolkykim.github.io/qlibc/doc/html/files.html)


### PR DESCRIPTION
Hello. I was checking the repo and decided to try out. I added an "installation" part on the readme that also specifies the standard.

The repo compiles successfully both for GNU99 and GNU23. I used both cmake and AutoTools. I modified CmakeLists.txt like so in line 32:
`SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu23")`
Same for GNU99.

When i tried strictly for C99 like this:
`SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -pedantic")`

It worked with AutoTools.
`./configure
make
sudo make install`

But C99 did NOT work when i tried cmake.
`mkdir build
cmake ..
make`

Gave an error like this:
`/home/user/qlibc/src/internal/qinternal.h:80:52: error: ‘PTHREAD_MUTEX_RECURSIVE’ undeclared (first use in this function); did you mean ‘PTHREAD_MUTEX_RECURSIVE_NP’?
   80 |             pthread_mutexattr_settype(&_mutexattr, PTHREAD_MUTEX_RECURSIVE); \`
   
  
fixes #115 